### PR TITLE
Fix na zmiane maksymalnej ilosci przyjmowanych ticketow

### DIFF
--- a/src/main/webapp/WEB-INF/spring-mvc.xml
+++ b/src/main/webapp/WEB-INF/spring-mvc.xml
@@ -20,8 +20,8 @@
 	<bean id="dataSource" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
 		<property name="driverClassName" value="com.mysql.jdbc.Driver"/>
 		<property name="url" value="jdbc:mysql://localhost:3306/sipdb"/>
-		<property name="username" value="mateusz"/>
-		<property name="password" value="123"/>
+		<property name="username" value="sipAccessUser"/>
+		<property name="password" value="sip"/>
 	</bean>
 	<mvc:resources mapping="/resources/**" location="/WEB-INF/resources/"/>
 </beans>


### PR DESCRIPTION
Ilość zamówień jest sterowana z poziomu kodu - należy zmienić `MAX_TICKETS_PER_DRIVER `
Usunąłem wcześniejsze sztywne ustawianie trasy i stworzyłem funkcję, która robi to samo, ale w pętli dla MAX_TICKETS_PER_DRIVER ticketów.
Jeśli ticketów będzie mniej niż zadany max, to teraz nie powinno się wywalić.
Nie testowałem dla liczby ticketów == 0.